### PR TITLE
Replaced Echo dependency from the core integration with a hook

### DIFF
--- a/.github/workflows/php-pr-checks.yml
+++ b/.github/workflows/php-pr-checks.yml
@@ -1,0 +1,82 @@
+name: PHPUnit / PHPCS / Phan
+on:
+  pull_request:
+    branches: '**'
+
+  push:
+    branches: [ master, MW_1_37, REL1_39 ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        php_version: ['8.0']
+        mw: ['REL1_39']
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php_version }}
+          # We don't run any coverage, so we should set this parameter to none
+          # as this will disable xdebug which slows all processes significantly
+          coverage: none
+          extensions: ast
+      - uses: actions/checkout@v3
+
+      - name: Checkout Mediawiki
+        uses: actions/checkout@v3
+        with:
+          repository: wikimedia/mediawiki
+          path: mediawiki
+          ref: ${{ matrix.mw }}
+
+      - name: Checkout Echo (dependency) extension
+        uses: actions/checkout@v3
+        with:
+          repository: wikimedia/mediawiki-extensions-Echo
+          path: mediawiki/extensions/Echo
+
+      - name: Checkout Flow (implicit dependency) extension
+        uses: actions/checkout@v3
+        with:
+          repository: wikimedia/mediawiki-extensions-Flow
+          path: mediawiki/extensions/Flow
+
+      - name: Checkout MobileFrontend (implicit dependency) extension
+        uses: actions/checkout@v3
+        with:
+          repository: wikimedia/mediawiki-extensions-MobileFrontend
+          path: mediawiki/extensions/MobileFrontend
+
+      - name: Checkout CheckUser (implicit dependency) extension
+        uses: actions/checkout@v3
+        with:
+          repository: wikimedia/mediawiki-extensions-CheckUser
+          path: mediawiki/extensions/CheckUser
+
+      - name: Checkout Thanks extension
+        uses: actions/checkout@v2
+        with:
+          path: mediawiki/extensions/Thanks
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-v3-${{ hashFiles('**/composer.lock') }}
+
+      - name: Install composer dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        working-directory: ./mediawiki/extensions/Thanks
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPCS
+        working-directory: ./mediawiki/extensions/Thanks
+        run: composer phpcs
+
+      - name: Run Phan static analysis
+        working-directory: ./mediawiki/extensions/Thanks
+        run: composer phan

--- a/extension.json
+++ b/extension.json
@@ -11,10 +11,7 @@
 	"license-name": "MIT",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.39.0",
-		"extensions": {
-			"Echo": "*"
-		}
+		"MediaWiki": ">= 1.39.0"
 	},
 	"DefaultUserOptions": {
 		"echo-subscriptions-web-edit-thank": true,

--- a/includes/ApiCoreThank.php
+++ b/includes/ApiCoreThank.php
@@ -4,8 +4,6 @@ namespace MediaWiki\Extension\Thanks;
 
 use ApiBase;
 use DatabaseLogEntry;
-use EchoDiscussionParser;
-use EchoEvent;
 use LogEntry;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
@@ -67,7 +65,6 @@ class ApiCoreThank extends ApiThank {
 		}
 		if ( $type === 'rev' ) {
 			$revision = $this->getRevisionFromId( $id );
-			$excerpt = EchoDiscussionParser::getEditExcerpt( $revision, $this->getLanguage() );
 			$title = $this->getTitleFromRevision( $revision );
 			$this->dieOnUserBlockedFromTitle( $user, $title );
 
@@ -90,7 +87,7 @@ class ApiCoreThank extends ApiThank {
 				$user,
 				$type,
 				$id,
-				$excerpt,
+				'', // We don't need the excerpt for our notification, and it would come from Echo
 				$recipient,
 				$this->getSourceFromParams( $params ),
 				$title,
@@ -221,8 +218,8 @@ class ApiCoreThank extends ApiThank {
 			return;
 		}
 
-		// Create the notification via Echo extension
-		EchoEvent::create( [
+		// Create notification via hook
+		$this->getHookContainer()->run( 'ThankCreated', [
 			'type' => 'edit-thank',
 			'title' => $title,
 			'extra' => [


### PR DESCRIPTION
As far as I can tell this is the minimal set of changes required for the extension to work, and let us override notification. There are more Echo references, and echo-specific hook handlers which I've decided to leave alone, as they seem to be dead code in our context, and removing them would introduce too much change from the original extension to remain easy to upgrade