### PR TITLE
UGC-4014 Adjust the extension to allow for our custom styling

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -176,7 +176,8 @@
 		"LocalUserCreated": "MediaWiki\\Extension\\Thanks\\Hooks::onAccountCreated",
 		"LogEventsListLineEnding": "MediaWiki\\Extension\\Thanks\\Hooks::onLogEventsListLineEnding",
 		"PageHistoryBeforeList": "MediaWiki\\Extension\\Thanks\\Hooks::onPageHistoryBeforeList",
-		"EnhancedChangesListModifyLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyLineData"
+		"EnhancedChangesListModifyLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyLineData",
+		"EnhancedChangesListModifyBlockLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyBlockLineData"
 	},
 	"config": {
 		"ThanksSendToBots": {

--- a/extension.json
+++ b/extension.json
@@ -173,7 +173,6 @@
 		"ApiMain::moduleManager": "MediaWiki\\Extension\\Thanks\\Hooks::onApiMainModuleManager",
 		"BeforeCreateEchoEvent": "MediaWiki\\Extension\\Thanks\\Hooks::onBeforeCreateEchoEvent",
 		"BeforePageDisplay": "MediaWiki\\Extension\\Thanks\\Hooks::onBeforePageDisplay",
-		"BeforeSpecialMobileDiffDisplay": "MediaWiki\\Extension\\Thanks\\Hooks::onBeforeSpecialMobileDiffDisplay",
 		"DiffTools": "MediaWiki\\Extension\\Thanks\\Hooks::onDiffTools",
 		"DifferenceEngineViewHeader": "MediaWiki\\Extension\\Thanks\\Hooks::onDifferenceEngineViewHeader",
 		"EchoGetBundleRules": "MediaWiki\\Extension\\Thanks\\Hooks::onEchoGetBundleRules",

--- a/extension.json
+++ b/extension.json
@@ -185,7 +185,8 @@
 		"LogEventsListLineEnding": "MediaWiki\\Extension\\Thanks\\Hooks::onLogEventsListLineEnding",
 		"PageHistoryBeforeList": "MediaWiki\\Extension\\Thanks\\Hooks::onPageHistoryBeforeList",
 		"EnhancedChangesListModifyLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyLineData",
-		"EnhancedChangesListModifyBlockLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyBlockLineData"
+		"EnhancedChangesListModifyBlockLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyBlockLineData",
+		"ContributionsLineEnding": "MediaWiki\\Extension\\Thanks\\Hooks::onContributionsLineEnding"
 	},
 	"config": {
 		"ThanksSendToBots": {

--- a/extension.json
+++ b/extension.json
@@ -73,6 +73,10 @@
 			"dependencies": [
 				"mediawiki.cookie",
 				"mediawiki.api"
+			],
+			"targets": [
+				"desktop",
+				"mobile"
 			]
 		},
 		"ext.thanks.corethank": {
@@ -98,6 +102,10 @@
 				"mediawiki.api",
 				"jquery.confirmable",
 				"ext.thanks"
+			],
+			"targets": [
+				"desktop",
+				"mobile"
 			]
 		},
 		"ext.thanks.mobilediff": {

--- a/extension.json
+++ b/extension.json
@@ -175,7 +175,8 @@
 		"HistoryTools": "MediaWiki\\Extension\\Thanks\\Hooks::onHistoryTools",
 		"LocalUserCreated": "MediaWiki\\Extension\\Thanks\\Hooks::onAccountCreated",
 		"LogEventsListLineEnding": "MediaWiki\\Extension\\Thanks\\Hooks::onLogEventsListLineEnding",
-		"PageHistoryBeforeList": "MediaWiki\\Extension\\Thanks\\Hooks::onPageHistoryBeforeList"
+		"PageHistoryBeforeList": "MediaWiki\\Extension\\Thanks\\Hooks::onPageHistoryBeforeList",
+		"EnhancedChangesListModifyLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyLineData"
 	},
 	"config": {
 		"ThanksSendToBots": {

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -494,4 +494,15 @@ class Hooks {
 		// Add parentheses to match what's done with Thanks in revision lists and diff displays.
 		$ret .= ' ' . wfMessage( 'parentheses' )->rawParams( $thankLink )->escaped();
 	}
+
+	public static function onEnhancedChangesListModifyLineData(
+		$changesList,
+		&$data,
+		$block,
+		$rc,
+		&$classes,
+		&$attribs
+	): void {
+		$element = 1;
+	}
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -503,21 +503,21 @@ class Hooks {
 	 * @link https://www.mediawiki.org/wiki/Manual:EnhancedChangesListModifyLineDataHook.php
 	 * @param EnhancedChangesList $changesList
 	 * @param array &$data
-	 * @param $block
+	 * @param RecentChange[] $block
 	 * @param RecentChange $rc
-	 * @param &$classes
-	 * @param &$attribs
+	 * @param string[] &$classes
+	 * @param string[] &$attribs
 	 * @return void
 	 */
 	public static function onEnhancedChangesListModifyLineData(
 		EnhancedChangesList $changesList,
 		array &$data,
-		$block,
+		array $block,
 		RecentChange $rc,
-		&$classes,
-		&$attribs
+		array &$classes,
+		array &$attribs
 	): void {
-		if ( in_array( 'ext.thanks.corethank', $changesList->getOutput()->getModules() ) === false ) {
+		if ( !in_array( 'ext.thanks.corethank', $changesList->getOutput()->getModules() ) ) {
 			self::addThanksModule( $changesList->getOutput() );
 		}
 		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();
@@ -542,7 +542,7 @@ class Hooks {
 		array &$data,
 		RecentChange $rc
 	): void {
-		if ( in_array( 'ext.thanks.corethank', $changesList->getOutput()->getModules() ) === false ) {
+		if ( !in_array( 'ext.thanks.corethank', $changesList->getOutput()->getModules() ) ) {
 			self::addThanksModule( $changesList->getOutput() );
 		}
 		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -9,6 +9,7 @@ use ConfigException;
 use DatabaseLogEntry;
 use DifferenceEngine;
 use EchoEvent;
+use EnhancedChangesList;
 use ExtensionRegistry;
 use Html;
 use ImagePage;
@@ -20,6 +21,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\User\UserIdentity;
 use MobileContext;
 use OutputPage;
+use RecentChange;
 use RequestContext;
 use Skin;
 use SpecialPage;
@@ -495,14 +497,59 @@ class Hooks {
 		$ret .= ' ' . wfMessage( 'parentheses' )->rawParams( $thankLink )->escaped();
 	}
 
+	/**
+	 * Fandom change UGC-4012 - Add thank link to the recent changes list
+	 *
+	 * @link https://www.mediawiki.org/wiki/Manual:EnhancedChangesListModifyLineDataHook.php
+	 * @param EnhancedChangesList $changesList
+	 * @param array &$data
+	 * @param $block
+	 * @param RecentChange $rc
+	 * @param &$classes
+	 * @param &$attribs
+	 * @return void
+	 */
 	public static function onEnhancedChangesListModifyLineData(
-		$changesList,
-		&$data,
+		EnhancedChangesList $changesList,
+		array &$data,
 		$block,
-		$rc,
+		RecentChange $rc,
 		&$classes,
 		&$attribs
 	): void {
-		$element = 1;
+		if ( in_array( 'ext.thanks.corethank', $changesList->getOutput()->getModules() ) === false ) {
+			self::addThanksModule( $changesList->getOutput() );
+		}
+		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();
+		self::insertThankLink(
+			$revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) ),
+			$data,
+			$changesList->getUser()
+		);
+	}
+
+	/**
+	 * Fandom change UGC-4012 - Add thank link to the recent changes list
+	 *
+	 * @link https://www.mediawiki.org/wiki/Manual:EnhancedChangesListModifyBlockLineDataHook.php
+	 * @param EnhancedChangesList $changesList
+	 * @param array &$data
+	 * @param RecentChange $rc
+	 * @return void
+	 */
+	public static function onEnhancedChangesListModifyBlockLineData(
+		EnhancedChangesList $changesList,
+		array &$data,
+		RecentChange $rc
+	): void {
+		if ( in_array( 'ext.thanks.corethank', $changesList->getOutput()->getModules() ) === false ) {
+			self::addThanksModule( $changesList->getOutput() );
+		}
+		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();
+		self::insertThankLink(
+			$revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) ),
+			$data,
+			$changesList->getUser()
+		);
 	}
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -6,6 +6,7 @@ use ApiModuleManager;
 use Article;
 use CategoryPage;
 use ConfigException;
+use ContribsPager;
 use DatabaseLogEntry;
 use DifferenceEngine;
 use EchoEvent;
@@ -25,6 +26,7 @@ use RecentChange;
 use RequestContext;
 use Skin;
 use SpecialPage;
+use stdClass;
 use Title;
 use User;
 use WikiPage;
@@ -551,5 +553,37 @@ class Hooks {
 			$data,
 			$changesList->getUser()
 		);
+	}
+
+	/**
+	 * Fandom change UGC-4012 - Add thank link to Special:Contributions page
+	 * @param ContribsPager $pager
+	 * @param string &$line
+	 * @param stdClass $row
+	 * @param array &$classes
+	 * @param array &$attribs
+	 * @return void
+	 */
+	public static function onContributionsLineEnding(
+		ContribsPager $pager,
+		string &$line,
+		stdClass $row,
+		array &$classes,
+		array &$attribs
+	): void {
+		$out = RequestContext::getMain()->getOutput();
+		if ( !in_array( 'ext.thanks.corethank', $out->getOutput()->getModules() ) ) {
+			self::addThanksModule( $out->getOutput() );
+		}
+		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();
+		$links = [];
+		self::insertThankLink(
+			$revLookup->getRevisionById( $row->rev_id ),
+			$links,
+			$out->getUser()
+		);
+		if ( isset( $links[0] ) ) {
+			$line .= $links[0];
+		}
 	}
 }

--- a/modules/ext.thanks.corethank.js
+++ b/modules/ext.thanks.corethank.js
@@ -52,7 +52,11 @@
 			.then(
 				// Success
 				function () {
-					$thankElement.before( mw.message( 'thanks-thanked', mw.user, $thankLink.data( 'recipient-gender' ) ).escaped() );
+					// FANDOM change. Gave the "before" element a class, so we can style it.
+					$thankElement.before( `<span class="mw-thanks-thank-confirmation">
+						${mw.message( 'thanks-thanked', mw.user, $thankLink.data( 'recipient-gender' ) ).escaped()}
+					</span>`);
+					// FANDOM change end.
 					$thankElement.remove();
 					mw.thanks.thanked.push( $thankLink.attr( attrName ) );
 				},

--- a/modules/ext.thanks.mobilediff.js
+++ b/modules/ext.thanks.mobilediff.js
@@ -64,7 +64,7 @@
 		var timeout,
 			button = new Button( {
 				progressive: true,
-				additionalClassNames: 'mw-mf-action-button'
+				additionalClassNames: 'mw-thanks-mobile-diff-thank-button mw-mf-action-button',
 			} ),
 			$button = button.$el;
 
@@ -136,13 +136,13 @@
 
 		$thankBtn = createThankLink( username, rev, gender );
 		if ( $thankBtn ) {
-			$thankBtn.prependTo( $container );
+			$thankBtn.appendTo( $container );
 		}
 
 	}
 
 	$( function () {
-		init( $( '.mw-mf-user' ), $( '#mw-mf-userinfo' ) );
+		init( $( '.mw-mf-user' ), $( '#mw-mf-userinfo > .post-content' ) );
 	} );
 
 	// Expose for testing purposes


### PR DESCRIPTION
## Links
- https://fandom.atlassian.net/browse/UGC-4012

## Description

### Added targets for core scripts
We'd like to use existing JS logic for mobile buttons. Default RL target is desktop, so I've added a mobile target to make sure they load on mobile pages.

### RecentChanges handling
The extension was not adding thank links to RecentChanges entries, so I added them via RC hooks

### Special:Contributions
Added support.

### Injecting JS on different selectors
To make the mobile experience more interactive, allow for core JS functions to execute on certain mobile buttons, like on a mobile diff page, or mobile history page.
