### PR TITLE
Fixed null pointer exception on RecentChanges

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -184,6 +184,7 @@
 		"LogEventsListLineEnding": "MediaWiki\\Extension\\Thanks\\Hooks::onLogEventsListLineEnding",
 		"PageHistoryBeforeList": "MediaWiki\\Extension\\Thanks\\Hooks::onPageHistoryBeforeList",
 		"EnhancedChangesListModifyLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyLineData",
+		"OldChangesListRecentChangesLine": "MediaWiki\\Extension\\Thanks\\Hooks::onOldChangesListRecentChangesLine",
 		"EnhancedChangesListModifyBlockLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyBlockLineData",
 		"ContributionsLineEnding": "MediaWiki\\Extension\\Thanks\\Hooks::onContributionsLineEnding"
 	},

--- a/extension.json
+++ b/extension.json
@@ -215,6 +215,9 @@
 				"rights/rights",
 				"lock"
 			]
+		},
+		"ThanksMaxLoadThankedPeriodDays": {
+			"value": 365
 		}
 	},
 	"manifest_version": 2

--- a/includes/ApiCoreThank.php
+++ b/includes/ApiCoreThank.php
@@ -8,6 +8,7 @@ use LogEntry;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\User\UserIdentity;
+use RequestContext;
 use Title;
 use User;
 use Wikimedia\ParamValidator\ParamValidator;
@@ -104,11 +105,16 @@ class ApiCoreThank extends ApiThank {
 	 * @return bool
 	 */
 	protected function userAlreadySentThanks( User $user, $type, $id ) {
-		if ( $type === 'rev' ) {
-			// For b/c with old-style keys
-			$type = '';
-		}
-		return (bool)$user->getRequest()->getSessionData( "thanks-thanked-$type$id" );
+		/**
+		 * Fandom change - start - UGC-4533 - Cache thanks data in session in a better way
+		 * @author Mkostrzewski
+		 */
+		return ( new ThanksCache(
+			MediaWikiServices::getInstance()->getDBLoadBalancer(),
+			MediaWikiServices::getInstance()->getMainConfig()
+		) )
+			->haveThanked( RequestContext::getMain(), $user->getActorId(), $id, $type );
+		// Fandom change - end
 	}
 
 	private function getRevisionFromId( $revId ) {
@@ -233,7 +239,15 @@ class ApiCoreThank extends ApiThank {
 		] );
 
 		// And mark the thank in session for a cheaper check to prevent duplicates (Phab:T48690).
-		$user->getRequest()->setSessionData( "thanks-thanked-$type$id", true );
+		/**
+		 * Fandom change - start - UGC-4533 - Cache thanks data in session in a better way
+		 * @author Mkostrzewski
+		 */
+		( new ThanksCache(
+			MediaWikiServices::getInstance()->getDBLoadBalancer(),
+			MediaWikiServices::getInstance()->getMainConfig()
+		) )->appendUserThanks( $this->getContext(), $user->getActorId(), $uniqueId );
+		// Fandom change - end
 		// Set success message
 		$this->markResultSuccess( $recipient->getName() );
 		$this->logThanks( $user, $recipient, $uniqueId );

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -614,7 +614,9 @@ class Hooks {
 			$out->getUser()
 		);
 		if ( isset( $links[0] ) ) {
-			$line .= $links[0];
+			// [UGC-4257] Wrap the thank link in a span so that it can be styled
+			$linkWithSpanParent = "<span class='mw-thanks-link-wrapper--contributions'>$links[0]</span>";
+			$line .= $linkWithSpanParent;
 		}
 	}
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -57,6 +57,11 @@ class Hooks {
 		?RevisionRecord $oldRevisionRecord,
 		UserIdentity $userIdentity
 	) {
+		// [UGC-4257] Don't show thank links if user doesn't have specific permission
+		if ( !ThanksPermissions::checkUserPermissionsForThanks( RequestContext::getMain()->getOutput() ) ) {
+			return;
+		}
+
 		self::insertThankLink( $revisionRecord,
 			$links, $userIdentity );
 	}

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -523,11 +523,14 @@ class Hooks {
 			self::addThanksModule( $changesList->getOutput() );
 		}
 		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();
-		self::insertThankLink(
-			$revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) ),
-			$data,
-			$changesList->getUser()
-		);
+		$revision = $revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) );
+		if ($revision) {
+			self::insertThankLink(
+				$revision,
+				$data,
+				$changesList->getUser()
+			);
+		}
 	}
 
 	/**
@@ -548,11 +551,14 @@ class Hooks {
 			self::addThanksModule( $changesList->getOutput() );
 		}
 		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();
-		self::insertThankLink(
-			$revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) ),
-			$data,
-			$changesList->getUser()
-		);
+		$revision = $revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) );
+		if ( $revision ) {
+			self::insertThankLink(
+				$revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) ),
+				$data,
+				$changesList->getUser()
+			);
+		}
 	}
 
 	/**

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -75,6 +75,13 @@ class Hooks {
 		?RevisionRecord $oldRevisionRecord,
 		UserIdentity $userIdentity
 	) {
+		$out = RequestContext::getMain()->getOutput();
+
+		// [UGC-4257] Don't show thank links if user doesn't have specific permission
+		if ( !ThanksPermissions::checkUserPermissionsForThanks( $out ) ) {
+			return;
+		}
+
 		// Don't allow thanking for a diff that includes multiple revisions
 		// This does a query that is too expensive for history rows (T284274)
 		$previous = MediaWikiServices::getInstance()
@@ -648,6 +655,12 @@ class Hooks {
 		array &$attribs
 	): void {
 		$out = RequestContext::getMain()->getOutput();
+
+		// [UGC-4257] Don't show thank links if user doesn't have specific permission
+		if ( !ThanksPermissions::checkUserPermissionsForThanks( $out ) ) {
+			return;
+		}
+
 		if ( !in_array( 'ext.thanks.corethank', $out->getOutput()->getModules() ) ) {
 			self::addThanksModule( $out->getOutput() );
 		}

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -21,6 +21,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\User\UserIdentity;
 use MobileContext;
+use OldChangesList;
 use OutputPage;
 use RecentChange;
 use RequestContext;
@@ -530,6 +531,30 @@ class Hooks {
 				$data,
 				$changesList->getUser()
 			);
+		}
+	}
+
+	public static function onOldChangesListRecentChangesLine(
+		OldChangesList $changesList,
+		&$s,
+		$rc,
+	) {
+		if ( !in_array( 'ext.thanks.corethank', $changesList->getOutput()->getModules() ) ) {
+			self::addThanksModule( $changesList->getOutput() );
+		}
+		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();
+		$revision = $revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) );
+		if ( $revision ) {
+			$holder = [];
+			self::insertThankLink(
+				$revision,
+				$holder,
+				$changesList->getUser()
+			);
+
+			if ( count( $holder ) ) {
+				$s .= ' ' . $holder[0];
+			}
 		}
 	}
 

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -524,7 +524,7 @@ class Hooks {
 		}
 		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();
 		$revision = $revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) );
-		if ($revision) {
+		if ( $revision ) {
 			self::insertThankLink(
 				$revision,
 				$data,

--- a/includes/ThanksCache.php
+++ b/includes/ThanksCache.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace MediaWiki\Extension\Thanks;
+
+use Config;
+use IContextSource;
+use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\Rdbms\SelectQueryBuilder;
+
+/**
+ * A service class that caches the list of IDs (revisions, logs) a user has thanked for.
+ * It uses a session as a backend.
+ */
+class ThanksCache {
+	private const THANKED_IDS_SESSION_KEY_PATTERN = "thanks-thanked-ids-%d";
+	/** @var ILoadBalancer */
+	private $lb;
+	/** @var Config */
+	private $config;
+
+	public function __construct( ILoadBalancer $lb, Config $config ) {
+		$this->lb = $lb;
+		$this->config = $config;
+	}
+
+	/**
+	 * Gets a cached list of entires for which a user has thanked.
+	 * Entires are refetched on cache miss.
+	 *
+	 * Each entry is in the same format as saved by the store (i.e. a string formatted as "$type-$id").
+	 * @param IContextSource $ctx - request context.
+	 * @param int $thankerActorId - actor ID of the user who thanked.
+	 * @return array An array of strings formatted as "$type-$id"
+	 */
+	public function getUserThanks( IContextSource $ctx, int $thankerActorId ): array {
+		$dbr = $this->lb->getConnection( DB_REPLICA );
+		$session = $ctx->getRequest()->getSession();
+
+		$key = sprintf( self::THANKED_IDS_SESSION_KEY_PATTERN, $thankerActorId );
+		$cachedRevs = $session->get( $key );
+		if ( $cachedRevs !== null ) {
+			return $cachedRevs;
+		}
+		$maxDays = $this->config->get( 'ThanksMaxLoadThankedPeriodDays' );
+		$dbEntries = $dbr->newSelectQueryBuilder()
+			->select( 'ls_value' )
+			->from( 'logging' )
+			->join( 'log_search', null, [ 'log_id = ls_log_id' ] )
+			->where(
+				[
+					'log_actor' => $thankerActorId,
+					'log_type' => 'thanks',
+					'log_timestamp BETWEEN ' .
+					$dbr->addQuotes( $dbr->timestamp( time() - 86400 * $maxDays ) ) .
+					' AND ' .
+					$dbr->addQuotes( $dbr->timestamp() ),
+					'ls_field' => 'thankid',
+				]
+			)
+			->orderBy( 'log_timestamp', SelectQueryBuilder::SORT_DESC )
+			->caller( __METHOD__ )
+			->fetchFieldValues();
+
+		$session->set( $key, $dbEntries );
+		return $dbEntries;
+	}
+
+	/**
+	 * Adds a new entry to the list of entires for which a user has thanked.
+	 * Note that it only updates the cache - clients have to make sure that the underlying data is consistent.
+	 * @param IContextSource $ctx - request context.
+	 * @param int $thankerActorId - actor ID of the user who thanked.
+	 * @param string $id - entry ID in the same format as saved by the store (i.e. a string formatted as "$type-$id").
+	 * @return array An array of strings formatted as "$type-$id"
+	 */
+	public function appendUserThanks( IContextSource $ctx, int $thankerActorId, string $id ): array {
+		$session = $ctx->getRequest()->getSession();
+		$key = sprintf( self::THANKED_IDS_SESSION_KEY_PATTERN, $thankerActorId );
+
+		$thankedCached = $session->get( $key );
+		if ( $thankedCached === null ) {
+			$thankedCached = self::getUserThanks( $ctx, $thankerActorId );
+		}
+		$thankedCached[] = $id;
+		$session->set( $key, $thankedCached );
+		return $thankedCached;
+	}
+
+	public function haveThanked( IContextSource $ctx, int $thankerActorId, int $id, string $type = 'rev' ): bool {
+		if ( $type === 'revision' ) {
+			$type = 'rev';
+		}
+		$value = "$type-$id";
+		return in_array( $value, self::getUserThanks( $ctx, $thankerActorId ) );
+	}
+}

--- a/includes/ThanksPermissions.php
+++ b/includes/ThanksPermissions.php
@@ -6,6 +6,8 @@ use Fandom\Includes\Mobile\MobileHelper;
 use MediaWiki\MediaWikiServices;
 
 class ThanksPermissions {
+	private const REQUIRE_USER_GROUPS = [ 'sysop', 'content-moderator', 'threadmoderator', 'rollback', 'staff',
+	'soap', 'wiki-representative', 'wiki-specialist' ];
 
 	/**
 	 * Check if the user is allowed to send thanks on pages:
@@ -18,6 +20,11 @@ class ThanksPermissions {
 	 */
 	public static function checkUserPermissionsForThanks( $out ) {
 		$user = $out->getUser();
+
+		if ( $user->isAnon() ) {
+			return false;
+		}
+
 		$isSpecialHistory = $out->getTitle()->isSpecial( 'History' );
 		$isMobileDiff = $out->getTitle()->isSpecial( 'MobileDiff' );
 		$isDiff = boolval( $out->getRequest()->getVal( 'diff' ) );
@@ -31,16 +38,6 @@ class ThanksPermissions {
 		$userGroupManager = MediaWikiServices::getInstance()->getUserGroupManager();
 		$userGroups = $userGroupManager->getUserEffectiveGroups( $user );
 
-		if ( $user->isAnon() ) {
-			return false;
-		}
-
-		if ( empty( array_intersect( $userGroups,
-			[ 'sysop', 'content-moderator', 'threadmoderator', 'rollback', 'staff', 'soap', 'wiki-representative', 'wiki-specialist' ]
-			) ) ) {
-			return false;
-		}
-
-		return true;
+		return !empty( array_intersect( $userGroups, self::REQUIRE_USER_GROUPS ) );
 	}
 }

--- a/includes/ThanksPermissions.php
+++ b/includes/ThanksPermissions.php
@@ -2,10 +2,22 @@
 
 namespace MediaWiki\Extension\Thanks;
 
-use Fandom\Includes\Mobile\MobileHelper;
 use MediaWiki\MediaWikiServices;
+use MobileContext;
 
 class ThanksPermissions {
+
+	private static function isMobile() {
+		if ( class_exists( 'MobileContext' ) ) {
+			/** @var MobileContext $mobileContext */
+			$mobileContext = MediaWikiServices::getInstance()->getService( 'MobileFrontend.Context' );
+
+			return $mobileContext->shouldDisplayMobileView();
+		}
+
+		return false;
+	}
+
 	private const REQUIRE_USER_GROUPS = [ 'sysop', 'content-moderator', 'threadmoderator', 'rollback', 'staff',
 	'soap', 'wiki-representative', 'wiki-specialist' ];
 
@@ -29,7 +41,7 @@ class ThanksPermissions {
 		$isMobileDiff = $out->getTitle()->isSpecial( 'MobileDiff' );
 		$isDiff = boolval( $out->getRequest()->getVal( 'diff' ) );
 		$isSpecialContributions = $out->getTitle()->isSpecial( 'Contributions' );
-		$isMobile = MobileHelper::isMobile();
+		$isMobile = self::isMobile();
 
 		if ( !( $isMobileDiff || $isDiff || $isSpecialContributions || ( $isSpecialHistory && $isMobile ) ) ) {
 			return true;

--- a/includes/ThanksPermissions.php
+++ b/includes/ThanksPermissions.php
@@ -38,12 +38,15 @@ class ThanksPermissions {
 		}
 
 		$isSpecialHistory = $out->getTitle()->isSpecial( 'History' );
+		$isHistory = $out->getRequest()->getVal( 'action', 'view' ) === 'history';
 		$isMobileDiff = $out->getTitle()->isSpecial( 'MobileDiff' );
 		$isDiff = boolval( $out->getRequest()->getVal( 'diff' ) );
 		$isSpecialContributions = $out->getTitle()->isSpecial( 'Contributions' );
 		$isMobile = self::isMobile();
 
-		if ( !( $isMobileDiff || $isDiff || $isSpecialContributions || ( $isSpecialHistory && $isMobile ) ) ) {
+		if ( !( $isMobileDiff || $isDiff || $isSpecialContributions ||
+			( ( $isSpecialHistory || $isHistory ) && $isMobile ) )
+		) {
 			return true;
 		}
 

--- a/includes/ThanksPermissions.php
+++ b/includes/ThanksPermissions.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace MediaWiki\Extension\Thanks;
+
+use Fandom\Includes\Mobile\MobileHelper;
+use MediaWiki\MediaWikiServices;
+
+class ThanksPermissions {
+
+	/**
+	 * Check if the user is allowed to send thanks on pages:
+	 * - Desktop Special:Contributions
+	 * - Desktop Special:History
+	 * - Mobile  Special:History
+	 * - Mobile  Special:Diff
+	 * @param \OutputPage $out
+	 * @return bool
+	 */
+	public static function checkUserPermissionsForThanks( $out ) {
+		$user = $out->getUser();
+		$isSpecialHistory = $out->getTitle()->isSpecial( 'History' );
+		$isMobileDiff = $out->getTitle()->isSpecial( 'MobileDiff' );
+		$isDiff = boolval( $out->getRequest()->getVal( 'diff' ) );
+		$isSpecialContributions = $out->getTitle()->isSpecial( 'Contributions' );
+		$isMobile = MobileHelper::isMobile();
+
+		if ( !( $isMobileDiff || $isDiff || $isSpecialContributions || ( $isSpecialHistory && $isMobile ) ) ) {
+			return true;
+		}
+
+		$userGroupManager = MediaWikiServices::getInstance()->getUserGroupManager();
+		$userGroups = $userGroupManager->getUserEffectiveGroups( $user );
+
+		if ( $user->isAnon() ) {
+			return false;
+		}
+
+		if ( empty( array_intersect( $userGroups,
+			[ 'sysop', 'content-moderator', 'threadmoderator', 'rollback', 'staff', 'soap', 'wiki-representative', 'wiki-specialist' ]
+			) ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/modules/ext.thanks.corethank.js
+++ b/modules/ext.thanks.corethank.js
@@ -132,5 +132,6 @@
 
 	mw.hook( 'wikipage.content' ).add( function ( $content ) {
 		addActionToLinks( $content );
+		reloadThankedState();
 	} );
 }() );

--- a/modules/ext.thanks.corethank.js
+++ b/modules/ext.thanks.corethank.js
@@ -129,4 +129,8 @@
 	mw.hook( 'wikipage.diff' ).add( function ( $content ) {
 		addActionToLinks( $content );
 	} );
+
+	mw.hook( 'wikipage.content' ).add( function ( $content ) {
+		addActionToLinks( $content );
+	} );
 }() );

--- a/modules/ext.thanks.corethank.js
+++ b/modules/ext.thanks.corethank.js
@@ -130,8 +130,12 @@
 		addActionToLinks( $content );
 	} );
 
-	mw.hook( 'wikipage.content' ).add( function ( $content ) {
-		addActionToLinks( $content );
-		reloadThankedState();
-	} );
+	// Add `wikipage.content` hook only to special pages that are dynamically reloading DOM
+	const specialPageName = mw.config.get( 'wgCanonicalSpecialPageName' );
+	if ( specialPageName === 'Recentchanges' || specialPageName === 'Watchlist' ) {
+		mw.hook( 'wikipage.content' ).add( function ( $content ) {
+			addActionToLinks( $content );
+			reloadThankedState();
+		} );
+	}
 }() );

--- a/modules/ext.thanks.thank.js
+++ b/modules/ext.thanks.thank.js
@@ -14,7 +14,12 @@
 			 * @return {string[]} Thanks IDs
 			 */
 			load: function ( cookieName ) {
-				var cookie = mw.cookie.get( cookieName || this.cookieName );
+				/**
+				 * Fandom change - start - UGC-4533 - Use localStorage instead of a cookie
+				 * @author Mkostrzewski
+				 */
+				var cookie = mw.storage.get( cookieName || this.cookieName );
+				// Fandom change - end
 				if ( cookie === null ) {
 					return [];
 				}
@@ -33,7 +38,12 @@
 				if ( saved.length > this.maxHistory ) { // prevent forever growing
 					saved = saved.slice( saved.length - this.maxHistory );
 				}
-				mw.cookie.set( cookieName || this.cookieName, escape( saved.join( ',' ) ) );
+				/**
+				 * Fandom change - start - UGC-4533 - Use localStorage instead of a cookie
+				 * @author Mkostrzewski
+				 */
+				mw.storage.set( cookieName || this.cookieName, escape( saved.join( ',' ) ) );
+				// Fandom change - end
 			},
 
 			/**


### PR DESCRIPTION
Fixes https://fandom.atlassian.net/browse/UGC-4167. 

The problem was null pointer exceptions in some rows in recent changes, and doing that one simple trick will make us safe for any scenario. 