### PR TITLE
Added thanks links on Recentchanges old changeslist

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -184,6 +184,7 @@
 		"LogEventsListLineEnding": "MediaWiki\\Extension\\Thanks\\Hooks::onLogEventsListLineEnding",
 		"PageHistoryBeforeList": "MediaWiki\\Extension\\Thanks\\Hooks::onPageHistoryBeforeList",
 		"EnhancedChangesListModifyLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyLineData",
+		"OldChangesListRecentChangesLine": "MediaWiki\\Extension\\Thanks\\Hooks::onOldChangesListRecentChangesLine",
 		"EnhancedChangesListModifyBlockLineData": "MediaWiki\\Extension\\Thanks\\Hooks::onEnhancedChangesListModifyBlockLineData",
 		"ContributionsLineEnding": "MediaWiki\\Extension\\Thanks\\Hooks::onContributionsLineEnding"
 	},

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -21,6 +21,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\User\UserIdentity;
 use MobileContext;
+use OldChangesList;
 use OutputPage;
 use RecentChange;
 use RequestContext;
@@ -530,6 +531,30 @@ class Hooks {
 				$data,
 				$changesList->getUser()
 			);
+		}
+	}
+
+	public static function onOldChangesListRecentChangesLine(
+		OldChangesList $changesList,
+		&$s,
+		$rc,
+	) {
+		if ( !in_array( 'ext.thanks.corethank', $changesList->getOutput()->getModules() ) ) {
+			self::addThanksModule( $changesList->getOutput() );
+		}
+		$revLookup = MediaWikiServices::getInstance()->getRevisionLookup();
+		$revision = $revLookup->getRevisionById( $rc->getAttribute( 'rc_this_oldid' ) );
+		if ( $revision ) {
+			$holder = [];
+			self::insertThankLink(
+				$revision,
+				$holder,
+				$changesList->getUser()
+			);
+
+			if ( count( $holder ) ) {
+				$s .= ' ' . $holder[0];
+			}
 		}
 	}
 


### PR DESCRIPTION
https://fandom.atlassian.net/browse/UGC-4168

The 	`Group changes by page in recent changes and watchlist` option in user preferences corresponds to `OldChangesList` and `EnhancedChangesList` in the code. They're using a different hook, so before this change we wouldn't support the "Old" one at all. 

One minor change in the hook interface is that for the the "Enhanced" one uses an array that represents the line in RC, for the "Old" one there is a string containing the whole HTML, so we can add the thanks link using concatenation