### PR TITLE
UGC-4319 React on wikipage.content event to reload thanks state

### DIFF
--- a/modules/ext.thanks.corethank.js
+++ b/modules/ext.thanks.corethank.js
@@ -132,5 +132,6 @@
 
 	mw.hook( 'wikipage.content' ).add( function ( $content ) {
 		addActionToLinks( $content );
+		reloadThankedState();
 	} );
 }() );

--- a/modules/ext.thanks.corethank.js
+++ b/modules/ext.thanks.corethank.js
@@ -129,4 +129,8 @@
 	mw.hook( 'wikipage.diff' ).add( function ( $content ) {
 		addActionToLinks( $content );
 	} );
+
+	mw.hook( 'wikipage.content' ).add( function ( $content ) {
+		addActionToLinks( $content );
+	} );
 }() );

--- a/modules/ext.thanks.corethank.js
+++ b/modules/ext.thanks.corethank.js
@@ -130,8 +130,12 @@
 		addActionToLinks( $content );
 	} );
 
-	mw.hook( 'wikipage.content' ).add( function ( $content ) {
-		addActionToLinks( $content );
-		reloadThankedState();
-	} );
+	// Add `wikipage.content` hook only to special pages that are dynamically reloading DOM
+	const specialPageName = mw.config.get( 'wgCanonicalSpecialPageName' );
+	if ( specialPageName === 'Recentchanges' || specialPageName === 'Watchlist' ) {
+		mw.hook( 'wikipage.content' ).add( function ( $content ) {
+			addActionToLinks( $content );
+			reloadThankedState();
+		} );
+	}
 }() );


### PR DESCRIPTION
* See https://fandom.atlassian.net/browse/UGC-4319

Recent Changes (and potentially other pages) can reload dynamically using JavaScript. Such a reload would cause the DOM to change and thus the previous JavaScript features to disappear. In our case, we would lose the dynamic "confirmable" feature of a thanks, and we would be redirected to a "thanks" confirm page instead.

Adding an observer for a `wikipage.content` event resolves the issue. After triggering the event, we would reattach actions to links, and we will reload thanked state.

This change has potential to break other pages, but from my observations they seem to work properly.