### PR TITLE
UGC-4533 Optimized backend cache for thanked links / localStorage for client cache

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -215,6 +215,9 @@
 				"rights/rights",
 				"lock"
 			]
+		},
+		"ThanksMaxLoadThankedPeriodDays": {
+			"value": 365
 		}
 	},
 	"manifest_version": 2

--- a/includes/ApiCoreThank.php
+++ b/includes/ApiCoreThank.php
@@ -8,6 +8,7 @@ use LogEntry;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\User\UserIdentity;
+use RequestContext;
 use Title;
 use User;
 use Wikimedia\ParamValidator\ParamValidator;
@@ -104,11 +105,16 @@ class ApiCoreThank extends ApiThank {
 	 * @return bool
 	 */
 	protected function userAlreadySentThanks( User $user, $type, $id ) {
-		if ( $type === 'rev' ) {
-			// For b/c with old-style keys
-			$type = '';
-		}
-		return (bool)$user->getRequest()->getSessionData( "thanks-thanked-$type$id" );
+		/**
+		 * Fandom change - start - UGC-4533 - Cache thanks data in session in a better way
+		 * @author Mkostrzewski
+		 */
+		return ( new ThanksCache(
+			MediaWikiServices::getInstance()->getDBLoadBalancer(),
+			MediaWikiServices::getInstance()->getMainConfig()
+		) )
+			->haveThanked( RequestContext::getMain(), $user->getActorId(), $id, $type );
+		// Fandom change - end
 	}
 
 	private function getRevisionFromId( $revId ) {
@@ -233,7 +239,15 @@ class ApiCoreThank extends ApiThank {
 		] );
 
 		// And mark the thank in session for a cheaper check to prevent duplicates (Phab:T48690).
-		$user->getRequest()->setSessionData( "thanks-thanked-$type$id", true );
+		/**
+		 * Fandom change - start - UGC-4533 - Cache thanks data in session in a better way
+		 * @author Mkostrzewski
+		 */
+		( new ThanksCache(
+			MediaWikiServices::getInstance()->getDBLoadBalancer(),
+			MediaWikiServices::getInstance()->getMainConfig()
+		) )->appendUserThanks( $this->getContext(), $user->getActorId(), $uniqueId );
+		// Fandom change - end
 		// Set success message
 		$this->markResultSuccess( $recipient->getName() );
 		$this->logThanks( $user, $recipient, $uniqueId );

--- a/includes/ThanksCache.php
+++ b/includes/ThanksCache.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace MediaWiki\Extension\Thanks;
+
+use Config;
+use IContextSource;
+use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\Rdbms\SelectQueryBuilder;
+
+/**
+ * A service class that caches the list of IDs (revisions, logs) a user has thanked for.
+ * It uses a session as a backend.
+ */
+class ThanksCache {
+	private const THANKED_IDS_SESSION_KEY_PATTERN = "thanks-thanked-ids-%d";
+	/** @var ILoadBalancer */
+	private $lb;
+	/** @var Config */
+	private $config;
+
+	public function __construct( ILoadBalancer $lb, Config $config ) {
+		$this->lb = $lb;
+		$this->config = $config;
+	}
+
+	/**
+	 * Gets a cached list of entires for which a user has thanked.
+	 * Entires are refetched on cache miss.
+	 *
+	 * Each entry is in the same format as saved by the store (i.e. a string formatted as "$type-$id").
+	 * @param IContextSource $ctx - request context.
+	 * @param int $thankerActorId - actor ID of the user who thanked.
+	 * @return array An array of strings formatted as "$type-$id"
+	 */
+	public function getUserThanks( IContextSource $ctx, int $thankerActorId ): array {
+		$dbr = $this->lb->getConnection( DB_REPLICA );
+		$session = $ctx->getRequest()->getSession();
+
+		$key = sprintf( self::THANKED_IDS_SESSION_KEY_PATTERN, $thankerActorId );
+		$cachedRevs = $session->get( $key );
+		if ( $cachedRevs !== null ) {
+			return $cachedRevs;
+		}
+		$maxDays = $this->config->get( 'ThanksMaxLoadThankedPeriodDays' );
+		$dbEntries = $dbr->newSelectQueryBuilder()
+			->select( 'ls_value' )
+			->from( 'logging' )
+			->join( 'log_search', null, [ 'log_id = ls_log_id' ] )
+			->where(
+				[
+					'log_actor' => $thankerActorId,
+					'log_type' => 'thanks',
+					'log_timestamp BETWEEN ' .
+					$dbr->addQuotes( $dbr->timestamp( time() - 86400 * $maxDays ) ) .
+					' AND ' .
+					$dbr->addQuotes( $dbr->timestamp() ),
+					'ls_field' => 'thankid',
+				]
+			)
+			->orderBy( 'log_timestamp', SelectQueryBuilder::SORT_DESC )
+			->caller( __METHOD__ )
+			->fetchFieldValues();
+
+		$session->set( $key, $dbEntries );
+		return $dbEntries;
+	}
+
+	/**
+	 * Adds a new entry to the list of entires for which a user has thanked.
+	 * Note that it only updates the cache - clients have to make sure that the underlying data is consistent.
+	 * @param IContextSource $ctx - request context.
+	 * @param int $thankerActorId - actor ID of the user who thanked.
+	 * @param string $id - entry ID in the same format as saved by the store (i.e. a string formatted as "$type-$id").
+	 * @return array An array of strings formatted as "$type-$id"
+	 */
+	public function appendUserThanks( IContextSource $ctx, int $thankerActorId, string $id ): array {
+		$session = $ctx->getRequest()->getSession();
+		$key = sprintf( self::THANKED_IDS_SESSION_KEY_PATTERN, $thankerActorId );
+
+		$thankedCached = $session->get( $key );
+		if ( $thankedCached === null ) {
+			$thankedCached = self::getUserThanks( $ctx, $thankerActorId );
+		}
+		$thankedCached[] = $id;
+		$session->set( $key, $thankedCached );
+		return $thankedCached;
+	}
+
+	public function haveThanked( IContextSource $ctx, int $thankerActorId, int $id, string $type = 'rev' ): bool {
+		if ( $type === 'revision' ) {
+			$type = 'rev';
+		}
+		$value = "$type-$id";
+		return in_array( $value, self::getUserThanks( $ctx, $thankerActorId ) );
+	}
+}

--- a/modules/ext.thanks.thank.js
+++ b/modules/ext.thanks.thank.js
@@ -14,7 +14,12 @@
 			 * @return {string[]} Thanks IDs
 			 */
 			load: function ( cookieName ) {
-				var cookie = mw.cookie.get( cookieName || this.cookieName );
+				/**
+				 * Fandom change - start - UGC-4533 - Use localStorage instead of a cookie
+				 * @author Mkostrzewski
+				 */
+				var cookie = mw.storage.get( cookieName || this.cookieName );
+				// Fandom change - end
 				if ( cookie === null ) {
 					return [];
 				}
@@ -33,7 +38,12 @@
 				if ( saved.length > this.maxHistory ) { // prevent forever growing
 					saved = saved.slice( saved.length - this.maxHistory );
 				}
-				mw.cookie.set( cookieName || this.cookieName, escape( saved.join( ',' ) ) );
+				/**
+				 * Fandom change - start - UGC-4533 - Use localStorage instead of a cookie
+				 * @author Mkostrzewski
+				 */
+				mw.storage.set( cookieName || this.cookieName, escape( saved.join( ',' ) ) );
+				// Fandom change - end
 			},
 
 			/**


### PR DESCRIPTION
Large cookies have caused multiple issues for us (see https://fandom.atlassian.net/wiki/spaces/PLAT/pages/2717909051/Issues+with+large+cookies for more information). Thanks uses cookies as a crude caching layer to memoize what a user has thanked for (revisions, log entries) to manage thank button's state. BE can conditionally render "thanked" state buttons - it implements an another storage for thanked entries in a session backend. This storage is dynamically updated upon thanking, so if somehow the session data is deleted, this no longer serves the purpose and leaves the state management to the frontend (cookies).

To fully get rid of cookies and delegate stateful rendering to only the backend I've:
- Replaced cookies with local storage for short-term memory, so that button states are persistent within a page load. This prevents a user from thanking for the same entry multiple times within a session
- BE now stores a full list of revisions that a user has thanked for in their session store. They are refetched directly from the DB if they are not found within the store, and that store is dynamically updated whenever a user thanks someone. This has a drawback of storing potentially hundreds of IDs.

I injected the new code in a pretty bad way - tried focusing on changing as few lines as possible to make future upstream merges easier. I'll rewrite this in a good way in an upstream patch that I'm planning to submit.