### PR TITLE
UGC-4573 Check permissions on desktop diff and special contributions …

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -57,6 +57,11 @@ class Hooks {
 		?RevisionRecord $oldRevisionRecord,
 		UserIdentity $userIdentity
 	) {
+		// [UGC-4257] Don't show thank links if user doesn't have specific permission
+		if ( !ThanksPermissions::checkUserPermissionsForThanks( RequestContext::getMain()->getOutput() ) ) {
+			return;
+		}
+
 		self::insertThankLink( $revisionRecord,
 			$links, $userIdentity );
 	}

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -75,6 +75,13 @@ class Hooks {
 		?RevisionRecord $oldRevisionRecord,
 		UserIdentity $userIdentity
 	) {
+		$out = RequestContext::getMain()->getOutput();
+
+		// [UGC-4257] Don't show thank links if user doesn't have specific permission
+		if ( !ThanksPermissions::checkUserPermissionsForThanks( $out ) ) {
+			return;
+		}
+
 		// Don't allow thanking for a diff that includes multiple revisions
 		// This does a query that is too expensive for history rows (T284274)
 		$previous = MediaWikiServices::getInstance()
@@ -648,6 +655,12 @@ class Hooks {
 		array &$attribs
 	): void {
 		$out = RequestContext::getMain()->getOutput();
+
+		// [UGC-4257] Don't show thank links if user doesn't have specific permission
+		if ( !ThanksPermissions::checkUserPermissionsForThanks( $out ) ) {
+			return;
+		}
+
 		if ( !in_array( 'ext.thanks.corethank', $out->getOutput()->getModules() ) ) {
 			self::addThanksModule( $out->getOutput() );
 		}

--- a/includes/ThanksPermissions.php
+++ b/includes/ThanksPermissions.php
@@ -6,6 +6,8 @@ use Fandom\Includes\Mobile\MobileHelper;
 use MediaWiki\MediaWikiServices;
 
 class ThanksPermissions {
+	private const REQUIRE_USER_GROUPS = [ 'sysop', 'content-moderator', 'threadmoderator', 'rollback', 'staff',
+	'soap', 'wiki-representative', 'wiki-specialist' ];
 
 	/**
 	 * Check if the user is allowed to send thanks on pages:
@@ -18,6 +20,11 @@ class ThanksPermissions {
 	 */
 	public static function checkUserPermissionsForThanks( $out ) {
 		$user = $out->getUser();
+
+		if ( $user->isAnon() ) {
+			return false;
+		}
+
 		$isSpecialHistory = $out->getTitle()->isSpecial( 'History' );
 		$isMobileDiff = $out->getTitle()->isSpecial( 'MobileDiff' );
 		$isDiff = boolval( $out->getRequest()->getVal( 'diff' ) );
@@ -31,16 +38,6 @@ class ThanksPermissions {
 		$userGroupManager = MediaWikiServices::getInstance()->getUserGroupManager();
 		$userGroups = $userGroupManager->getUserEffectiveGroups( $user );
 
-		if ( $user->isAnon() ) {
-			return false;
-		}
-
-		if ( empty( array_intersect( $userGroups,
-			[ 'sysop', 'content-moderator', 'threadmoderator', 'rollback', 'staff', 'soap', 'wiki-representative', 'wiki-specialist' ]
-			) ) ) {
-			return false;
-		}
-
-		return true;
+		return !empty( array_intersect( $userGroups, self::REQUIRE_USER_GROUPS ) );
 	}
 }

--- a/includes/ThanksPermissions.php
+++ b/includes/ThanksPermissions.php
@@ -2,10 +2,22 @@
 
 namespace MediaWiki\Extension\Thanks;
 
-use Fandom\Includes\Mobile\MobileHelper;
 use MediaWiki\MediaWikiServices;
+use MobileContext;
 
 class ThanksPermissions {
+
+	private static function isMobile() {
+		if ( class_exists( 'MobileContext' ) ) {
+			/** @var MobileContext $mobileContext */
+			$mobileContext = MediaWikiServices::getInstance()->getService( 'MobileFrontend.Context' );
+
+			return $mobileContext->shouldDisplayMobileView();
+		}
+
+		return false;
+	}
+
 	private const REQUIRE_USER_GROUPS = [ 'sysop', 'content-moderator', 'threadmoderator', 'rollback', 'staff',
 	'soap', 'wiki-representative', 'wiki-specialist' ];
 
@@ -29,7 +41,7 @@ class ThanksPermissions {
 		$isMobileDiff = $out->getTitle()->isSpecial( 'MobileDiff' );
 		$isDiff = boolval( $out->getRequest()->getVal( 'diff' ) );
 		$isSpecialContributions = $out->getTitle()->isSpecial( 'Contributions' );
-		$isMobile = MobileHelper::isMobile();
+		$isMobile = self::isMobile();
 
 		if ( !( $isMobileDiff || $isDiff || $isSpecialContributions || ( $isSpecialHistory && $isMobile ) ) ) {
 			return true;

--- a/includes/ThanksPermissions.php
+++ b/includes/ThanksPermissions.php
@@ -38,12 +38,15 @@ class ThanksPermissions {
 		}
 
 		$isSpecialHistory = $out->getTitle()->isSpecial( 'History' );
+		$isHistory = $out->getRequest()->getVal( 'action', 'view' ) === 'history';
 		$isMobileDiff = $out->getTitle()->isSpecial( 'MobileDiff' );
 		$isDiff = boolval( $out->getRequest()->getVal( 'diff' ) );
 		$isSpecialContributions = $out->getTitle()->isSpecial( 'Contributions' );
 		$isMobile = self::isMobile();
 
-		if ( !( $isMobileDiff || $isDiff || $isSpecialContributions || ( $isSpecialHistory && $isMobile ) ) ) {
+		if ( !( $isMobileDiff || $isDiff || $isSpecialContributions ||
+			( ( $isSpecialHistory || $isHistory ) && $isMobile ) )
+		) {
 			return true;
 		}
 

--- a/includes/ThanksPermissions.php
+++ b/includes/ThanksPermissions.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace MediaWiki\Extension\Thanks;
+
+use Fandom\Includes\Mobile\MobileHelper;
+use MediaWiki\MediaWikiServices;
+
+class ThanksPermissions {
+
+	/**
+	 * Check if the user is allowed to send thanks on pages:
+	 * - Desktop Special:Contributions
+	 * - Desktop Special:History
+	 * - Mobile  Special:History
+	 * - Mobile  Special:Diff
+	 * @param \OutputPage $out
+	 * @return bool
+	 */
+	public static function checkUserPermissionsForThanks( $out ) {
+		$user = $out->getUser();
+		$isSpecialHistory = $out->getTitle()->isSpecial( 'History' );
+		$isMobileDiff = $out->getTitle()->isSpecial( 'MobileDiff' );
+		$isDiff = boolval( $out->getRequest()->getVal( 'diff' ) );
+		$isSpecialContributions = $out->getTitle()->isSpecial( 'Contributions' );
+		$isMobile = MobileHelper::isMobile();
+
+		if ( !( $isMobileDiff || $isDiff || $isSpecialContributions || ( $isSpecialHistory && $isMobile ) ) ) {
+			return true;
+		}
+
+		$userGroupManager = MediaWikiServices::getInstance()->getUserGroupManager();
+		$userGroups = $userGroupManager->getUserEffectiveGroups( $user );
+
+		if ( $user->isAnon() ) {
+			return false;
+		}
+
+		if ( empty( array_intersect( $userGroups,
+			[ 'sysop', 'content-moderator', 'threadmoderator', 'rollback', 'staff', 'soap', 'wiki-representative', 'wiki-specialist' ]
+			) ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}


### PR DESCRIPTION
https://fandom.atlassian.net/browse/UGC-4573

## Description
- Require permission to display thanks on listed pages: 
  - permissions: 
    - [sysops, content moderators, threadmoderators, rollbacks,
    - global rights holder, i.e. staff, soap, wiki reps and wiki specialists
  - pages:
    - Special:Contributions pages
    - Desktop diff pages